### PR TITLE
37 add dynamic naming for events

### DIFF
--- a/dap_rt_reporter/funcs.py
+++ b/dap_rt_reporter/funcs.py
@@ -2,15 +2,42 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
 import json
+import re
+
 from dap_rt_reporter.types import DAPMessage
 
 
 def write_process_event(timestamp, event, csv_writer, debugger_connection):
-    csv_writer.writerow([timestamp, event["type"], event["sub_type"], event["name"]])
+    csv_writer.writerow(
+        [
+            timestamp,
+            event["type"],
+            event["sub_type"],
+            get_event_name(event["name"], debugger_connection),
+        ]
+    )
+
 
 def write_variable_value_assign(timestamp, event, csv_writer, debugger_connection):
+    csv_writer.writerow(
+        [
+            timestamp,
+            event["type"],
+            event["sub_type"],
+            get_event_name(event["name"], debugger_connection),
+            evaluate_expression(event["args"]["variable"], debugger_connection),
+        ]
+    )
+
+
+def evaluate_expression(expression, debugger_connection):
+    """Evaluate expression in current context inside SUT."""
+
+    if ("{" and "}") in expression:
+        expression = re.findall(r"{(.*?)}", expression)[0]
+
     result = None
-    encoded_response = debugger_connection.evaluate(event["args"]["variable"])
+    encoded_response = debugger_connection.evaluate(expression)
     # encoded_response = debugger_connection.evaluate("_x")
     while result is None:
         response_list = parse_dap_response(encoded_response)
@@ -28,9 +55,20 @@ def write_variable_value_assign(timestamp, event, csv_writer, debugger_connectio
         if not encoded_response:
             encoded_response = debugger_connection.idle()
 
-    csv_writer.writerow(
-        [timestamp, event["type"], event["sub_type"], event["name"], result]
+    return result
+
+
+def get_event_name(event_name_raw, debugger_connection):
+    """Evaluate expressions inside the event name."""
+
+    event_name = re.sub(
+        r"{(.*?)}",
+        lambda match: evaluate_expression(match.group(), debugger_connection),
+        event_name_raw,
     )
+
+    return event_name
+
 
 def parse_dap_response(response: bytes):
     """Converts DAP response to dictionary form.

--- a/dap_rt_reporter/funcs.py
+++ b/dap_rt_reporter/funcs.py
@@ -33,9 +33,6 @@ def write_variable_value_assign(timestamp, event, csv_writer, debugger_connectio
 def evaluate_expression(expression, debugger_connection):
     """Evaluate expression in current context inside SUT."""
 
-    if ("{" and "}") in expression:
-        expression = re.findall(r"{(.*?)}", expression)[0]
-
     result = None
     encoded_response = debugger_connection.evaluate(expression)
     # encoded_response = debugger_connection.evaluate("_x")
@@ -63,7 +60,9 @@ def get_event_name(event_name_raw, debugger_connection):
 
     event_name = re.sub(
         r"{(.*?)}",
-        lambda match: evaluate_expression(match.group(), debugger_connection),
+        lambda match: evaluate_expression(
+            re.findall(r"{(.*?)}", match.group())[0], debugger_connection
+        ),
         event_name_raw,
     )
 


### PR DESCRIPTION
Events can be named by evaluating expressions, for example:

event_{i}, loop_{x}, {y+x}_value

Or any other form using {} and an expression using variables inside the SUT.