### PR TITLE
52 add handler for sudden program ending

### DIFF
--- a/dap_rt_reporter/__main__.py
+++ b/dap_rt_reporter/__main__.py
@@ -35,7 +35,6 @@ parser.add_argument("--desc", help="configuration file", required=True)
 parser.add_argument("--log", help="log file to store report", required=True)
 parser.add_argument("-f", help="force log rewrite", action="store_true")
 parser.add_argument("--sut-args", help="add argument for SUT", nargs="+")
-parser.add_argument("--timeout", help="amount of time in seconds to run the reporter")
 
 args = parser.parse_args()
 
@@ -44,7 +43,6 @@ config_file = args.desc
 log_path = args.log
 force = args.f
 sut_args = " ".join(args.sut_args) if args.sut_args else ""
-timeout = args.timeout
 
 # Checks
 if not os.path.isfile(sut):
@@ -53,15 +51,8 @@ if not os.path.isfile(config_file):
     raise RuntimeError(f"No file named {config_file} exists.")
 if os.path.isfile(log_path) and not force:
     raise RuntimeError(f"Warning: {log_path} already exists, use -f to force rewrite.")
-if timeout:
-    if timeout.isdigit():
-        timeout = int(timeout)
-    else:
-        raise RuntimeError(f"{timeout} is not a valid number.")
-else:
-    timeout = 0
 
-reporter = Reporter(sut, log_path, sut_args, timeout)
+reporter = Reporter(sut, log_path, sut_args)
 
 print("Reading configuration file...")
 # Read each line and add corresponding events

--- a/dap_rt_reporter/__main__.py
+++ b/dap_rt_reporter/__main__.py
@@ -159,7 +159,7 @@ with open(config_file, "r") as workflow_file:
             case _:
                 raise RuntimeError(f"Event {event} is undefined.")
 
-signal.signal(signal.Signals.SIGINT, (lambda signum, frame: reporter.kill()))
+signal.signal(signal.SIGINT, (lambda signum, frame: reporter.kill()))
 reporter.execute()
 
 reporter.close()

--- a/dap_rt_reporter/__main__.py
+++ b/dap_rt_reporter/__main__.py
@@ -4,6 +4,7 @@
 import csv
 import argparse
 import os
+import signal
 
 from dap_rt_reporter.types import ReportEvent
 from dap_rt_reporter.reporter import Reporter
@@ -158,6 +159,7 @@ with open(config_file, "r") as workflow_file:
             case _:
                 raise RuntimeError(f"Event {event} is undefined.")
 
+signal.signal(signal.Signals.SIGINT, (lambda signum, frame: reporter.kill()))
 reporter.execute()
 
 reporter.close()

--- a/dap_rt_reporter/__main__.py
+++ b/dap_rt_reporter/__main__.py
@@ -5,6 +5,7 @@ import csv
 import argparse
 import os
 import signal
+import logging
 
 from dap_rt_reporter.types import ReportEvent
 from dap_rt_reporter.reporter import Reporter
@@ -19,6 +20,8 @@ from dap_rt_reporter.event.clock_pause import ClockPauseEvent
 from dap_rt_reporter.event.clock_reset import ClockResetEvent
 from dap_rt_reporter.event.clock_resume import ClockResumeEvent
 from dap_rt_reporter.event.component_event import ComponentEvent
+
+logging.basicConfig(encoding="utf-8", level=logging.INFO, format="%(levelname)s::%(message)s")
 
 # Parser arguments
 parser = argparse.ArgumentParser(
@@ -55,7 +58,7 @@ if os.path.isfile(log_path) and not force:
 
 reporter = Reporter(sut, log_path, sut_args)
 
-print("Reading configuration file...")
+logging.info("Reading configuration file")
 # Read each line and add corresponding events
 with open(config_file, "r") as workflow_file:
     workflow_reader = csv.reader(workflow_file, delimiter=",")
@@ -159,7 +162,6 @@ with open(config_file, "r") as workflow_file:
             case _:
                 raise RuntimeError(f"Event {event} is undefined.")
 
-signal.signal(signal.SIGINT, (lambda signum, frame: reporter.kill()))
+signal.signal(signal.SIGINT, reporter.kill)
 reporter.execute()
-
 reporter.close()

--- a/dap_rt_reporter/connection_wrapper.py
+++ b/dap_rt_reporter/connection_wrapper.py
@@ -4,18 +4,21 @@
 import dap
 from dap_rt_reporter.stdio_handler import STDIOHandler
 
-
 class ConnectionWrapper:
     """Wrapper for the connection between the DAP client and debugger."""
 
     def __init__(self, executable: str, executable_args: str, timeout=1.0) -> None:
         self.timeout = timeout
         self.executable_args = executable_args
+        self.alive = True
 
         launch_command = ["gdb", "-i=dap", "--quiet", executable]
             
         self.stdio_handler = STDIOHandler(launch_command)
         self.dap_client = dap.Client("DAP Client")
+
+    def is_alive(self):
+        return self.alive
 
     def _send(self):
         """Clears the DAP client buffer and writes the commands to the stdio pipe,

--- a/dap_rt_reporter/event/event.py
+++ b/dap_rt_reporter/event/event.py
@@ -41,7 +41,7 @@ class Event(ABC):
         result = None
         encoded_response = debugger_connection.evaluate(expression)
         # encoded_response = debugger_connection.evaluate("_x")
-        while result is None:
+        while result is None and debugger_connection.is_alive():
             response_list = self.parse_dap_response(encoded_response)
             encoded_response = b""
 

--- a/dap_rt_reporter/listener.py
+++ b/dap_rt_reporter/listener.py
@@ -19,7 +19,7 @@ class Listener:
             
             # Wait until step is completed
             # TODO: Check if timeout or other checks are necessary
-            while b"stopped" not in encoded_response:
+            while b"stopped" not in encoded_response and debugger_connection.is_alive():
                 encoded_response = debugger_connection.idle()
 
             for event in self.events[breakpoint_id]["a"]:

--- a/dap_rt_reporter/reporter.py
+++ b/dap_rt_reporter/reporter.py
@@ -3,6 +3,7 @@
 
 import csv
 import time
+import logging
 
 from dap_rt_reporter.connection_wrapper import ConnectionWrapper
 from dap_rt_reporter.types import DAPEvent, DAPMessage
@@ -41,11 +42,11 @@ class Reporter:
             self._set_up()
 
             # Start execution
-            print("Starting SUT execution")
+            logging.info("Starting SUT execution")
             encoded_response = self.debugger_connection.launch()
             terminated = False
 
-            while not terminated and self.alive:
+            while not terminated and self.debugger_connection.is_alive():
                 response_list = Event.parse_dap_response(encoded_response)
                 encoded_response = b""
 
@@ -71,13 +72,14 @@ class Reporter:
                 if not encoded_response:
                     encoded_response = self.debugger_connection.idle()
 
-        print("Closing reporter.")
+        logging.info("Closing reporter")
 
         return terminated
 
     def _set_up(self):
         """Sets breakpoints and gives the events to listener."""
 
+        logging.info("Setting breakpoints")
         # Create breakpoint locations
         breakpoint_locations = {}
         for event in self.events:
@@ -115,6 +117,7 @@ class Reporter:
             source_dap_form = {"name": source, "path": source_path}
 
             # Set breakpoints and clear previous ones
+            logging.debug("Setting breakpoints for %s", source_dap_form["name"])
             encoded_response = self.debugger_connection.set_breakpoints_source(
                 source_dap_form, lines_dap_form
             )
@@ -122,9 +125,10 @@ class Reporter:
             # Check breakpoints verification
             # Read all responses until verification is confirmed
             breakpoint_verification = False
-            while not breakpoint_verification:
+            while not breakpoint_verification and self.debugger_connection.is_alive():# and self.alive:
                 response_list = Event.parse_dap_response(encoded_response)
                 for response in response_list:
+                    #logging.debug("At breakpoint verification DAP response: %s", response)
                     if (
                         response["type"] == DAPMessage.RESPONSE
                         and response["command"] == "setBreakpoints"
@@ -138,10 +142,11 @@ class Reporter:
 
                 encoded_response = self.debugger_connection.idle()
 
-    def kill(self):
+    def kill(self, segnum=0, frame=""):
         """Kill reporter. Stops SUT execution but allow events set up to be completed."""
 
-        self.alive = False
+        logging.debug("Killing reporter at : %s and segnum %d", frame, segnum)
+        self.debugger_connection.alive = False
 
     def set_event(self, event: Event):
         """Set new event to report."""
@@ -149,4 +154,5 @@ class Reporter:
         self.events.append(event)
 
     def close(self):
+        logging.info("Closing debugger connection.")
         self.debugger_connection.close_connection()

--- a/dap_rt_reporter/reporter.py
+++ b/dap_rt_reporter/reporter.py
@@ -20,14 +20,13 @@ class Reporter:
         executable_path: str,
         execution_trace_log_path: str,
         executable_args: str = "",
-        timeout: int = 0,
     ) -> None:
         self.debugger_connection = ConnectionWrapper(executable_path, executable_args)
         self.listener = Listener()
 
         self.executable_path = executable_path
         self.execution_trace_log_path = execution_trace_log_path
-        self.timeout = timeout
+        self.alive = True
 
         # Used for saving events
         self.events = []
@@ -45,8 +44,8 @@ class Reporter:
             print("Starting SUT execution")
             encoded_response = self.debugger_connection.launch()
             terminated = False
-            start_time = time.time()
-            while not terminated:
+
+            while not terminated and self.alive:
                 response_list = Event.parse_dap_response(encoded_response)
                 encoded_response = b""
 
@@ -61,7 +60,9 @@ class Reporter:
                                     csv_writer,
                                     self.debugger_connection,
                                 )
-                            encoded_response = self.debugger_connection.continue_execution()
+                            encoded_response = (
+                                self.debugger_connection.continue_execution()
+                            )
                         elif response["event"] == DAPEvent.TERMINATED:
                             terminated = True
                     elif response["type"] == DAPMessage.RESPONSE:
@@ -70,10 +71,7 @@ class Reporter:
                 if not encoded_response:
                     encoded_response = self.debugger_connection.idle()
 
-                if self.timeout != 0 and time.time() - start_time >= self.timeout:
-                    terminated = True
-
-            print("Closing reporter.")
+        print("Closing reporter.")
 
         return terminated
 
@@ -139,6 +137,11 @@ class Reporter:
                         breakpoint_verification = True
 
                 encoded_response = self.debugger_connection.idle()
+
+    def kill(self):
+        """Kill reporter. Stops SUT execution but allow events set up to be completed."""
+
+        self.alive = False
 
     def set_event(self, event: Event):
         """Set new event to report."""

--- a/dap_rt_reporter/reporter.py
+++ b/dap_rt_reporter/reporter.py
@@ -27,7 +27,6 @@ class Reporter:
 
         self.executable_path = executable_path
         self.execution_trace_log_path = execution_trace_log_path
-        self.alive = True
 
         # Used for saving events
         self.events = []
@@ -125,10 +124,10 @@ class Reporter:
             # Check breakpoints verification
             # Read all responses until verification is confirmed
             breakpoint_verification = False
-            while not breakpoint_verification and self.debugger_connection.is_alive():# and self.alive:
+            while not breakpoint_verification and self.debugger_connection.is_alive():
                 response_list = Event.parse_dap_response(encoded_response)
                 for response in response_list:
-                    #logging.debug("At breakpoint verification DAP response: %s", response)
+                    # logging.debug("At breakpoint verification DAP response: %s", response)
                     if (
                         response["type"] == DAPMessage.RESPONSE
                         and response["command"] == "setBreakpoints"

--- a/dap_rt_reporter/reporter.py
+++ b/dap_rt_reporter/reporter.py
@@ -35,46 +35,45 @@ class Reporter:
     def execute(self):
         """Begins program execution and report."""
 
-        report_file = open(self.execution_trace_log_path, "w")
-        csv_writer = csv.writer(report_file, delimiter=",")
+        with open(self.execution_trace_log_path, "w") as report_file:
+            csv_writer = csv.writer(report_file, delimiter=",")
 
-        self.debugger_connection.start()
-        self._set_up()
+            self.debugger_connection.start()
+            self._set_up()
 
-        # Start execution
-        print("Starting SUT execution")
-        encoded_response = self.debugger_connection.launch()
-        terminated = False
-        start_time = time.time()
-        while not terminated:
-            response_list = Event.parse_dap_response(encoded_response)
-            encoded_response = b""
+            # Start execution
+            print("Starting SUT execution")
+            encoded_response = self.debugger_connection.launch()
+            terminated = False
+            start_time = time.time()
+            while not terminated:
+                response_list = Event.parse_dap_response(encoded_response)
+                encoded_response = b""
 
-            # Logic to control program execution
-            for response in response_list:
-                if response["type"] == DAPMessage.EVENT:
-                    if response["event"] == DAPEvent.STOPPED:
-                        if response["body"]["reason"] == "breakpoint":
-                            self.listener.handle_response(
-                                int(1e6 * time.time()),
-                                response,
-                                csv_writer,
-                                self.debugger_connection,
-                            )
-                        encoded_response = self.debugger_connection.continue_execution()
-                    elif response["event"] == DAPEvent.TERMINATED:
-                        terminated = True
-                elif response["type"] == DAPMessage.RESPONSE:
-                    pass
+                # Logic to control program execution
+                for response in response_list:
+                    if response["type"] == DAPMessage.EVENT:
+                        if response["event"] == DAPEvent.STOPPED:
+                            if response["body"]["reason"] == "breakpoint":
+                                self.listener.handle_response(
+                                    int(1e6 * time.time()),
+                                    response,
+                                    csv_writer,
+                                    self.debugger_connection,
+                                )
+                            encoded_response = self.debugger_connection.continue_execution()
+                        elif response["event"] == DAPEvent.TERMINATED:
+                            terminated = True
+                    elif response["type"] == DAPMessage.RESPONSE:
+                        pass
 
-            if not encoded_response:
-                encoded_response = self.debugger_connection.idle()
+                if not encoded_response:
+                    encoded_response = self.debugger_connection.idle()
 
-            if self.timeout != 0 and time.time() - start_time >= self.timeout:
-                terminated = True
+                if self.timeout != 0 and time.time() - start_time >= self.timeout:
+                    terminated = True
 
-        report_file.close()
-        print("Closing reporter.")
+            print("Closing reporter.")
 
         return terminated
 

--- a/dap_rt_reporter/stdio_handler.py
+++ b/dap_rt_reporter/stdio_handler.py
@@ -83,4 +83,7 @@ class STDIOHandler:
             self.debugger_subprocess.stderr.close()
 
         self.debugger_subprocess.terminate()
-        self.debugger_subprocess.wait()
+        try:
+            self.debugger_subprocess.wait(1)
+        except subprocess.TimeoutExpired:
+            self.debugger_subprocess.kill()


### PR DESCRIPTION
A SIGINT handler now stops SUT execution allowing the report file to close, no handler is used before execution begins. Events set up will always finish, but reading from configuration can be stopped.